### PR TITLE
Feat/tec 671 update node version check updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -38,7 +38,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -17,20 +17,30 @@
     "upgrade",
     "versions"
   ],
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.cjs",
+      "types": "./dist/types/index.d.ts"
+    }
+  },
   "files": [
     "dist"
   ],
   "bin": {
-    "check-updates": "./dist/index.js"
+    "check-updates": "./dist/cjs/index.cjs"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/zityhub/check-updates"
   },
   "scripts": {
-    "build": "rimraf dist && tsc",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:cjs": "tsc -p tsconfig.cjs.json && mv dist/cjs/index.js dist/cjs/index.cjs",
+    "build": "rimraf dist && npm run build:esm && npm run build:cjs",
     "dev": "tsx index.ts",
     "format": "prettier . --write",
     "lint": "eslint . --fix"

--- a/package.json
+++ b/package.json
@@ -1,13 +1,9 @@
 {
   "name": "@zityhub/check-updates",
-  "version": "3.0.0",
+  "version": "2.1.0",
   "author": "Zityhub",
   "license": "MIT",
   "description": "Project that checks if your project has any dependencies that have been updated with a major version.",
-  "engines": {
-    "node": ">=24.0.0",
-    "npm": ">=10.9.2"
-  },
   "packageManager": "pnpm@10.11.0",
   "keywords": [
     "dependencies",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "description": "Project that checks if your project has any dependencies that have been updated with a major version.",
   "engines": {
-    "node": ">=22.13.0",
+    "node": ">=24.0.0",
     "npm": ">=10.9.2"
   },
   "packageManager": "pnpm@10.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zityhub/check-updates",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "author": "Zityhub",
   "license": "MIT",
   "description": "Project that checks if your project has any dependencies that have been updated with a major version.",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node16",
+    "outDir": "dist/cjs",
+    "declaration": false
+  },
+  "include": ["index.ts"]
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -2,9 +2,7 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "module": "ESNext",
-    "moduleResolution": "bundler",
-    "types": [],
-    "noEmit": true
+    "moduleResolution": "node"
   },
   "include": ["index.ts", "eslint.config.mjs"]
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -3,8 +3,9 @@
   "compilerOptions": {
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "types": [],
-    "noEmit": true
+    "outDir": "dist/esm",
+    "declaration": true,
+    "declarationDir": "dist/types"
   },
-  "include": ["index.ts", "eslint.config.mjs"]
+  "include": ["index.ts"]
 }


### PR DESCRIPTION
Esta PR cierra [#TEC-671](https://zityhub.atlassian.net/browse/TEC-671)

### Descripción

- Se ha añadido han añadido archivos tsconfig para poder compilar en ambos tipos de modulos CJS y ESM
- Se han modificado los scripts del package
- Se ha modificado el archivo de CI para githubactions para usar la autenticación con OIDC
- Se ha modificado el github actions para tener jobs separados para build y publish

### Aceptación

- [ ] Revisar código

### Información adicional

Para cuando pase la PR:
- Crear etiqueta `git tag v3.0.0`
- Pushear etiqueta `git push origin v3.0.0`


