### PR TITLE
feat/TEC-783 pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ The command will return an error if there are any packages that need a major ver
 
 ## Exclude Packages
 
-You can ignore specific dependencies to ensure the check returns an exit code 0:
+You can ignore specific dependencies to ensure the check returns an exit code 0.
+Excluded dependencies are reported as info (exit code 0) instead of failing:
 
 ```sh
 check-updates --exclude=awilix --exclude=jsonpath-plus --exclude=stripe
@@ -52,6 +53,24 @@ check-updates --exclude=awilix --exclude=jsonpath-plus --exclude=stripe
     "data": {
       "jobName": "check-updates",
       "message": "Major update available for: awilix,jsonpath-plus,stripe"
+    }
+  }
+}
+```
+
+If some dependencies still have a pending major update after applying the
+excludes, only those are notified and the command returns an error:
+
+```sh
+check-updates --exclude=awilix
+
+2024-10-08T18:34:51.341Z ERROR Job check-updates finished failed
+{
+  "type": {
+    "name": "job",
+    "data": {
+      "jobName": "check-updates",
+      "message": "Major update available for: jsonpath-plus,stripe"
     }
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -62,10 +62,12 @@ const main = async (exclude: string[]) => {
     (packageName) => !exclude.includes(packageName)
   )
 
-  const message = `Major update available for: ${packages.join(',')}`
-  if (toUpdate.length) return Promise.reject(message)
+  const prefix = `Major update available for:`
+  if (toUpdate.length) return Promise.reject(`${prefix} ${toUpdate.join(',')}`)
 
-  return Promise.resolve(packages.length ? message : undefined)
+  return Promise.resolve(
+    packages.length ? `${prefix} ${packages.join(',')}` : undefined
+  )
 }
 
 main(parseArguments(process.argv.slice(2)))


### PR DESCRIPTION
Esta PR cierra [#TEC-783](https://zityhub.atlassian.net/browse/TEC-783)

### Descripción

- Se ha modificado el script para que solo notifique las librerías que no están en el exclude

### Aceptación

- [x] Hacer una build del proyecto `node --run build`
- [x] Ves al proyecto de api y corre `node ../check-updates/dist/cjs/index.cjs`
- [x] Verifica que salen todas las dependencias
- [x] Vuelve a correrlo pero añadiendo el exclude de redis `node ../check-updates/dist/cjs/index.cjs --exclude=redis`
- [x] Ya no debería salir redis en el error
- [x] Añade todos los excludes `node ../check-updates/dist/cjs/index.cjs --exclude=redis --exclude=@eslint/js --exclude=eslint --exclude=eslint-plugin-n --exclude=pnpm`
- [x] El script debería dar success pero con un mensaje de todas las dependencias a actualizar
- [x] revisa el código


